### PR TITLE
Input args

### DIFF
--- a/mgefinder/workflow.py
+++ b/mgefinder/workflow.py
@@ -17,9 +17,9 @@ def _workflow(workdir, snakefile, configfile, cores, memory, unlock, rerun_incom
     cmd = 'snakemake -s {snakefile} --config wd={workdir} memory={memory} ' \
           '--cores {cores} --configfile {configfile}'
     if rerun_incomplete:
-        cmd += '--rerun-incomplete '
+        cmd += ' --rerun-incomplete '
     if keep_going:
-        cmd += '--keep-going'
+        cmd += ' --keep-going'
     
     cmd = cmd.format(snakefile=snakefile, configfile=configfile, workdir=workdir, memory=memory, cores=cores)
     print('COMMAND:', cmd)


### PR DESCRIPTION
Args '--rerun-incomplete' and '--keep-going' (lines 20 and 22) does not work without space after 'configfile'.
A space after '{configfile}' at line 18 can be a good solution also.